### PR TITLE
Fix TON timer not counting when same instance used in multiple rungs

### DIFF
--- a/src/components/actions/SimulateButton.tsx
+++ b/src/components/actions/SimulateButton.tsx
@@ -53,7 +53,7 @@ const SimulateButton: React.FC = () => {
       timer = id;
     }
     return () => clearInterval(timer);
-  });
+  }, [simulation]);
 
   const handleClick = () => {
     logEvent('click_simulation');

--- a/src/helpers/cycleScan.ts
+++ b/src/helpers/cycleScan.ts
@@ -296,7 +296,7 @@ const setTimerOut = (element: ElementTimer, RLO: boolean, simulation: boolean, v
   const timerUuid = element.parameters.inOut[0].uuid;
 
   if (executedTimers.has(timerUuid)) {
-    element.out = variables[Q].value as boolean;
+    element.out = RLO && (variables[Q].value as boolean);
     return element.out;
   }
   executedTimers.add(timerUuid);

--- a/src/helpers/cycleScan.ts
+++ b/src/helpers/cycleScan.ts
@@ -6,6 +6,7 @@ import { NUMBER_MAX, NUMBER_MIN } from '../consts/variables';
 
 export const cycleScan = (draft: Store): Store => {
   const { branches, elements, rungs } = draft;
+  const executedTimers = new Set<string>();
   const branchOut = (branchId: string, RLO: boolean) => {
     const branch = draft.branches[branchId];
     branch.input = RLO;
@@ -41,7 +42,7 @@ export const cycleScan = (draft: Store): Store => {
       case ELEMENT_TYPES.TOF:
       case ELEMENT_TYPES.TON:
       case ELEMENT_TYPES.TONR:
-        return setTimerOut(element, RLO, simulation, variables);
+        return setTimerOut(element, RLO, simulation, variables, executedTimers);
       case ELEMENT_TYPES.ADD:
       case ELEMENT_TYPES.SUB:
       case ELEMENT_TYPES.MUL:
@@ -287,11 +288,19 @@ const setMoveOut = (element: ElementMove, RLO: boolean, variables: { [key: strin
   return element.out;
 };
 
-const setTimerOut = (element: ElementTimer, RLO: boolean, simulation: boolean, variables: { [key: string]: Variable }): boolean => {
+const setTimerOut = (element: ElementTimer, RLO: boolean, simulation: boolean, variables: { [key: string]: Variable }, executedTimers: Set<string>): boolean => {
   const inOut = variables[element.parameters.inOut[0].uuid];
   if (!inOut?.subVars) return false;
   const { PT, ET, IN, R, Q } = inOut.subVars;
   const { type } = element;
+  const timerUuid = element.parameters.inOut[0].uuid;
+
+  if (executedTimers.has(timerUuid)) {
+    element.out = variables[Q].value as boolean;
+    return element.out;
+  }
+  executedTimers.add(timerUuid);
+
   variables[IN].value = RLO;
   const ptValue = variables[PT].value;
   let etValue = variables[ET].value;


### PR DESCRIPTION
## Summary

- **Root cause:** When the same TON timer function block was placed in two
  different rungs, `cycleScan` called `setTimerOut` twice per scan cycle.
  The second call (with `RLO=false` from an open contact) would reset `ET`
  to 0, cancelling the increment from the first call — so the timer never
  counted.
- **Fix 1:** Track executed timer UUIDs per scan cycle with a `Set`. On
  the second encounter of the same timer instance, skip re-execution and
  return the current output instead.
- **Fix 2:** The early-return path was returning raw `Q` without gating by
  the incoming `RLO`. This caused downstream coils to be energized even
  when the contact before the timer was open. Changed to `RLO && Q` to
  match standard TON ladder logic behavior.
- **Bonus fix:** Added `[simulation]` dependency array to `useEffect` in
  `SimulateButton.tsx` to prevent the scan interval from being recreated
  on every render.

## Test plan

- [ ] Place a TON timer in a rung with a NC contact — verify ET increments
- [ ] Place the same TON instance in a second rung with an open XIC contact
      — verify it does NOT energize its output coil and does NOT reset ET
- [ ] Verify timer completes (ET == PT → Q = true) and coils set correctly
- [ ] Verify timers reset when simulation is stopped